### PR TITLE
Enhance PPO training metrics

### DIFF
--- a/scripts/train_ppo.py
+++ b/scripts/train_ppo.py
@@ -1,17 +1,20 @@
 import argparse
 import sys
 from pathlib import Path
+from collections import deque
+
+from torch.utils.tensorboard import SummaryWriter
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from agents.deep.ppo import PPOAgent, Step
-from agents.random_agent import RandomAgent
+from agents.tabular_q import TabularQAgent
 from envs.otrio_env import OtrioEnv
 
 
-def play_episode(env: OtrioEnv, learner: PPOAgent, opponent: RandomAgent):
+def play_episode(env: OtrioEnv, learner: PPOAgent, opponent: TabularQAgent):
     obs, info = env.reset()
     player = info["current_player"]
     steps: list[Step] = []
@@ -27,8 +30,18 @@ def play_episode(env: OtrioEnv, learner: PPOAgent, opponent: RandomAgent):
             last_agent_step = step
             player = env.current_player
         else:
-            action = opponent.select_action(env.board, player)
+            prev_board = env.board.clone()
+            action = opponent.select_action(prev_board, player)
             obs, reward, done, info = env.step(action)
+            opponent.update(
+                prev_board,
+                player,
+                action,
+                reward,
+                env.board.clone(),
+                env.current_player,
+                done,
+            )
             if done and info.get("winner") == player and last_agent_step is not None:
                 last_agent_step.reward = -1.0
             player = env.current_player
@@ -44,29 +57,43 @@ def play_episode(env: OtrioEnv, learner: PPOAgent, opponent: RandomAgent):
 def train(episodes: int = 1000, checkpoint: str | None = None, load: str | None = None):
     env = OtrioEnv(players=2)
     learner = PPOAgent()
-    opponent = RandomAgent()
+    opponent = TabularQAgent()
     if load:
         learner.load(load)
-    win_count = 0
+
+    writer = SummaryWriter()
+    recent_results: deque[int] = deque(maxlen=50)
     batch: list[Step] = []
+
     for ep in range(1, episodes + 1):
         steps, info = play_episode(env, learner, opponent)
         batch.extend(steps)
-        if info.get("winner") == 0:
-            win_count += 1
+
+        win = 1 if info.get("winner") == 0 else 0
+        recent_results.append(win)
+        episode_length = len(steps)
+        win_rate = sum(recent_results) / len(recent_results)
+
+        writer.add_scalar("win", win, ep)
+        writer.add_scalar("episode_length", episode_length, ep)
+        writer.add_scalar("win_rate_recent", win_rate, ep)
+
         if ep % 10 == 0:
             learner.update(batch)
             batch.clear()
+
         if ep % 50 == 0:
-            print(f"Episode {ep}: win rate {win_count}/{ep}")
+            print(f"Episode {ep}: last {len(recent_results)}-episode win rate {win_rate * 100:.1f}%")
             if checkpoint:
                 learner.save(checkpoint)
+
+    writer.close()
     if checkpoint:
         learner.save(checkpoint)
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Train a PPO agent against a random opponent")
+    parser = argparse.ArgumentParser(description="Train a PPO agent against a tabular Q-learning opponent")
     parser.add_argument("--episodes", type=int, default=1000)
     parser.add_argument("--checkpoint", type=str, default=None)
     parser.add_argument("--load", type=str, default=None)


### PR DESCRIPTION
## Summary
- log episodic metrics to TensorBoard
- track recent win percentage instead of cumulative
- play against a learning Tabular Q opponent instead of the random agent

## Testing
- `pytest -q`