### PR TITLE
Enhance PPO training metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,4 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+runs/

--- a/README.md
+++ b/README.md
@@ -128,6 +128,10 @@ python scripts/play_vs_ppo.py --model ppo_agent.pkl
 ```
 
 Logs (TensorBoard & CSV) land in `./runs/`, checkpoints in `./checkpoints/`.
+To visualize training metrics, run:
+```bash
+tensorboard --logdir runs
+```
 
 ---
 

--- a/agents/deep/ppo.py
+++ b/agents/deep/ppo.py
@@ -101,7 +101,8 @@ class PPOAgent:
         clip_ratio = torch.clamp(ratio, 1 - self.clip_eps, 1 + self.clip_eps)
         policy_loss = -(torch.min(ratio * advs, clip_ratio * advs)).mean()
         value_loss = F.mse_loss(values, returns)
-        return policy_loss + 0.5 * value_loss
+        loss = policy_loss + 0.5 * value_loss
+        return loss, policy_loss, value_loss
 
     def update(self, steps: List[Step], epochs: int = 3, batch_size: int = 8):
         obs = torch.tensor([s.obs for s in steps], dtype=torch.float32)
@@ -112,11 +113,14 @@ class PPOAgent:
         advs = torch.tensor([s.adv for s in steps], dtype=torch.float32)
         advs = (advs - advs.mean()) / (advs.std() + 1e-8)
 
+        losses = []
+        policy_losses = []
+        value_losses = []
         for _ in range(epochs):
             perm = torch.randperm(len(steps))
             for start in range(0, len(steps), batch_size):
                 idx = perm[start:start + batch_size]
-                loss = self._compute_loss(
+                loss, pol, val = self._compute_loss(
                     obs[idx],
                     masks[idx],
                     actions[idx],
@@ -127,6 +131,15 @@ class PPOAgent:
                 self.optimizer.zero_grad()
                 loss.backward()
                 self.optimizer.step()
+                losses.append(loss.item())
+                policy_losses.append(pol.item())
+                value_losses.append(val.item())
+
+        return {
+            "loss": float(sum(losses) / len(losses)),
+            "policy_loss": float(sum(policy_losses) / len(policy_losses)),
+            "value_loss": float(sum(value_losses) / len(value_losses)),
+        }
 
     def save(self, path: str):
         torch.save(

--- a/scripts/train_ppo.py
+++ b/scripts/train_ppo.py
@@ -1,17 +1,20 @@
 import argparse
 import sys
 from pathlib import Path
+from collections import deque
+
+from torch.utils.tensorboard import SummaryWriter
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from agents.deep.ppo import PPOAgent, Step
-from agents.random_agent import RandomAgent
+from agents.tabular_q import TabularQAgent
 from envs.otrio_env import OtrioEnv
 
 
-def play_episode(env: OtrioEnv, learner: PPOAgent, opponent: RandomAgent):
+def play_episode(env: OtrioEnv, learner: PPOAgent, opponent: TabularQAgent):
     obs, info = env.reset()
     player = info["current_player"]
     steps: list[Step] = []
@@ -27,8 +30,18 @@ def play_episode(env: OtrioEnv, learner: PPOAgent, opponent: RandomAgent):
             last_agent_step = step
             player = env.current_player
         else:
-            action = opponent.select_action(env.board, player)
+            prev_board = env.board.clone()
+            action = opponent.select_action(prev_board, player)
             obs, reward, done, info = env.step(action)
+            opponent.update(
+                prev_board,
+                player,
+                action,
+                reward,
+                env.board.clone(),
+                env.current_player,
+                done,
+            )
             if done and info.get("winner") == player and last_agent_step is not None:
                 last_agent_step.reward = -1.0
             player = env.current_player
@@ -44,29 +57,51 @@ def play_episode(env: OtrioEnv, learner: PPOAgent, opponent: RandomAgent):
 def train(episodes: int = 1000, checkpoint: str | None = None, load: str | None = None):
     env = OtrioEnv(players=2)
     learner = PPOAgent()
-    opponent = RandomAgent()
+    opponent = TabularQAgent()
     if load:
         learner.load(load)
-    win_count = 0
+
+    writer = SummaryWriter()
+    writer.add_text(
+        "hparams",
+        f"lr={learner.lr}, gamma={learner.gamma}, clip_eps={learner.clip_eps}",
+        global_step=0,
+    )
+    recent_results: deque[int] = deque(maxlen=50)
     batch: list[Step] = []
+
     for ep in range(1, episodes + 1):
         steps, info = play_episode(env, learner, opponent)
         batch.extend(steps)
-        if info.get("winner") == 0:
-            win_count += 1
+
+        win = 1 if info.get("winner") == 0 else 0
+        recent_results.append(win)
+        episode_length = len(steps)
+        win_rate = sum(recent_results) / len(recent_results)
+
+        writer.add_scalar("win", win, ep)
+        writer.add_scalar("episode_length", episode_length, ep)
+        writer.add_scalar("win_rate_recent", win_rate, ep)
+
         if ep % 10 == 0:
-            learner.update(batch)
+            metrics = learner.update(batch)
+            writer.add_scalar("loss", metrics["loss"], ep)
+            writer.add_scalar("policy_loss", metrics["policy_loss"], ep)
+            writer.add_scalar("value_loss", metrics["value_loss"], ep)
             batch.clear()
+
         if ep % 50 == 0:
-            print(f"Episode {ep}: win rate {win_count}/{ep}")
+            print(f"Episode {ep}: last {len(recent_results)}-episode win rate {win_rate * 100:.1f}%")
             if checkpoint:
                 learner.save(checkpoint)
+
+    writer.close()
     if checkpoint:
         learner.save(checkpoint)
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Train a PPO agent against a random opponent")
+    parser = argparse.ArgumentParser(description="Train a PPO agent against a tabular Q-learning opponent")
     parser.add_argument("--episodes", type=int, default=1000)
     parser.add_argument("--checkpoint", type=str, default=None)
     parser.add_argument("--load", type=str, default=None)


### PR DESCRIPTION
## Summary
- log episodic metrics to TensorBoard
- track recent win percentage instead of cumulative
- play against a learning Tabular Q opponent instead of the random agent
- record PPO update losses in TensorBoard
- add tip for launching TensorBoard

## Testing
- `pytest -q`
