### PR TITLE
Fix PPO network input mismatch

### DIFF
--- a/agents/deep/ppo.py
+++ b/agents/deep/ppo.py
@@ -39,6 +39,9 @@ class PPOAgent:
         self.lr = lr
         self.gamma = gamma
         self.clip_eps = clip_eps
+        self.gae_lambda = gae_lambda
+        self.entropy_coef = entropy_coef
+        self.max_grad_norm = max_grad_norm
         # two players × three sizes × 3x3 board plus
         # current-player indicator and win-move counts for each player
         self.input_dim = len(SIZES) * BOARD_SIZE * BOARD_SIZE * 2 + 3
@@ -85,24 +88,7 @@ class PPOAgent:
         vec.append(float(self._num_winning_moves(board, 1)))
         # indicate whose turn it is
         vec.append(float(player))
-
-        # Append counts of immediate winning moves for the agent and opponent
-        vec.append(float(self._num_winning_moves(board, player)))
-        vec.append(float(self._num_winning_moves(board, 1 - player)))
         return vec
-
-    def _num_winning_moves(self, board: Board, player: int) -> int:
-        """Count legal moves that would immediately win for the given player."""
-        count = 0
-        for r in range(BOARD_SIZE):
-            for c in range(BOARD_SIZE):
-                for s in SIZES:
-                    if board.is_legal(player, r, c, s):
-                        board.apply_move(player, r, c, s)
-                        if board.check_win(player):
-                            count += 1
-                        board.grid[r][c][s] = None
-        return count
 
     def _legal_mask(self, board: Board, player: int) -> List[int]:
         mask = []


### PR DESCRIPTION
## Summary
- fix PPO feature encoding to match declared input dimension
- remove duplicate helper and store training hyperparameters
- all tests pass

## Testing
- `pytest -q`