### PR TITLE
Fix PPO loss computation

### DIFF
--- a/agents/deep/ppo.py
+++ b/agents/deep/ppo.py
@@ -39,6 +39,9 @@ class PPOAgent:
         self.lr = lr
         self.gamma = gamma
         self.clip_eps = clip_eps
+        self.gae_lambda = gae_lambda
+        self.entropy_coef = entropy_coef
+        self.max_grad_norm = max_grad_norm
         # two players × three sizes × 3x3 board plus
         # current-player indicator and win-move counts for each player
         self.input_dim = len(SIZES) * BOARD_SIZE * BOARD_SIZE * 2 + 3
@@ -85,24 +88,7 @@ class PPOAgent:
         vec.append(float(self._num_winning_moves(board, 1)))
         # indicate whose turn it is
         vec.append(float(player))
-
-        # Append counts of immediate winning moves for the agent and opponent
-        vec.append(float(self._num_winning_moves(board, player)))
-        vec.append(float(self._num_winning_moves(board, 1 - player)))
         return vec
-
-    def _num_winning_moves(self, board: Board, player: int) -> int:
-        """Count legal moves that would immediately win for the given player."""
-        count = 0
-        for r in range(BOARD_SIZE):
-            for c in range(BOARD_SIZE):
-                for s in SIZES:
-                    if board.is_legal(player, r, c, s):
-                        board.apply_move(player, r, c, s)
-                        if board.check_win(player):
-                            count += 1
-                        board.grid[r][c][s] = None
-        return count
 
     def _legal_mask(self, board: Board, player: int) -> List[int]:
         mask = []
@@ -147,7 +133,8 @@ class PPOAgent:
         policy_loss = -(torch.min(ratio * advs, clip_ratio * advs)).mean()
         value_loss = F.mse_loss(values, returns)
         entropy = -(log_probs.exp() * log_probs).sum(-1).mean()
-        return policy_loss + 0.5 * value_loss - self.entropy_coef * entropy
+        loss = policy_loss + 0.5 * value_loss - self.entropy_coef * entropy
+        return loss, policy_loss, value_loss
 
     def update(self, steps: List[Step], epochs: int = 4, batch_size: int = 512):
         obs = torch.tensor([s.obs for s in steps], dtype=torch.float32)


### PR DESCRIPTION
## Summary
- return policy and value losses from `_compute_loss`
- include previously missing training hyperparameters and fix feature encoding

## Testing
- `pytest -q`
- `python scripts/train_ppo.py --episodes 1 --checkpoint /tmp/ppo.pkl`