### PR TITLE
Randomize starting player

### DIFF
--- a/envs/otrio_env.py
+++ b/envs/otrio_env.py
@@ -1,4 +1,5 @@
 from typing import Tuple, Dict, Any
+import random
 
 from otrio.board import Board
 from otrio.pieces import Size
@@ -11,12 +12,12 @@ class OtrioEnv:
     def __init__(self, players: int = 2):
         self.players = players
         self.board = Board(players)
-        self.current_player = 0
+        self.current_player = random.randrange(players)
         self.done = False
 
     def reset(self) -> Tuple[Any, Dict[str, Any]]:
         self.board.reset()
-        self.current_player = 0
+        self.current_player = random.randrange(self.players)
         self.done = False
         return self.board.to_observation(), {"current_player": self.current_player}
 

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -14,3 +14,12 @@ def test_environment_playthrough():
         obs, reward, done, info = env.step(action)
         moves += 1
     assert done
+
+
+def test_start_player_randomized():
+    env = OtrioEnv(players=2)
+    starts = set()
+    for _ in range(20):
+        _, info = env.reset()
+        starts.add(info["current_player"])
+    assert starts == {0, 1}


### PR DESCRIPTION
## Summary
- pick random starting player in OtrioEnv
- test that reset() alternates starting player over many episodes

## Testing
- `pytest -q`