### PR TITLE
Add reward shaping and flexible PPO architectures

### DIFF
--- a/envs/otrio_env.py
+++ b/envs/otrio_env.py
@@ -35,14 +35,21 @@ class OtrioEnv:
             info["illegal_move"] = True
             obs = self.board.to_observation()
             return obs, reward, False, info
+        opponent = (self.current_player + 1) % self.players
+        before = self.board.num_winning_moves(opponent)
         self.board.apply_move(self.current_player, row, col, size)
+        after = self.board.num_winning_moves(opponent)
         if self.board.check_win(self.current_player):
             reward = 1.0
+            if after < before:
+                reward += 0.1 * (before - after)
             self.done = True
             info["winner"] = self.current_player
         elif self.board.is_full():
             self.done = True
         else:
+            if after < before:
+                reward += 0.1 * (before - after)
             self.current_player = (self.current_player + 1) % self.players
         obs = self.board.to_observation()
         return obs, reward, self.done, info

--- a/otrio/board.py
+++ b/otrio/board.py
@@ -98,3 +98,16 @@ class Board:
                     if owner is not None:
                         obs[owner][s][r][c] = 1
         return obs
+
+    def num_winning_moves(self, player: int) -> int:
+        """Return the number of legal moves that would immediately win."""
+        count = 0
+        for r in range(BOARD_SIZE):
+            for c in range(BOARD_SIZE):
+                for s in SIZES:
+                    if self.is_legal(player, r, c, s):
+                        self.grid[r][c][s] = player
+                        if self.check_win(player):
+                            count += 1
+                        self.grid[r][c][s] = None
+        return count


### PR DESCRIPTION
## Summary
- reward agent for blocking opponent's immediate win
- expose new network architectures for PPO: two-layer MLP and conv+MLP
- support saving/loading conv parameters

## Testing
- `pytest -q`