### PR TITLE
Improve CLI rendering in play_vs_ppo

### DIFF
--- a/scripts/play_vs_ppo.py
+++ b/scripts/play_vs_ppo.py
@@ -12,12 +12,25 @@ from otrio.pieces import Size
 from otrio.utils import BOARD_SIZE, SIZES
 
 
+def print_reference_grid():
+    """Print the board well numbering once at game start."""
+    for r in range(BOARD_SIZE):
+        row = []
+        for c in range(BOARD_SIZE):
+            idx = r * BOARD_SIZE + c
+            row.append(str(idx))
+        print(' '.join(row))
+    print()
+
+
 def render(board):
     for r in range(BOARD_SIZE):
         cells = []
         for c in range(BOARD_SIZE):
             cell = board.grid[r][c]
-            cells.append(''.join(str(cell[s]) if cell[s] is not None else '.' for s in SIZES))
+            cell_str = ''.join(str(cell[s]) if cell[s] is not None else '.' for s in SIZES)
+            idx = r * BOARD_SIZE + c
+            cells.append(f"{idx}:{cell_str}")
         print(' '.join(cells))
     print()
 
@@ -25,7 +38,7 @@ def render(board):
 def prompt_move(board, player):
     while True:
         try:
-            well = int(input("Select well (0-8): "))
+            well = int(input("Select well index (0-8, row-major as shown): "))
             size = int(input("Select size (0:small 1:medium 2:large): "))
             row, col = divmod(well, BOARD_SIZE)
             s = Size(size)
@@ -36,12 +49,15 @@ def prompt_move(board, player):
             print("Invalid input, try again.")
 
 
-def play(model_path: str, human_player: int = 1):
+def play(model_path: str, human_player: int = 1, show_grid: bool = False):
     env = OtrioEnv(players=2)
     agent = PPOAgent()
     agent.load(model_path)
 
     obs, info = env.reset()
+    if show_grid:
+        print("Well indices:")
+        print_reference_grid()
     player = info["current_player"]
     done = False
 
@@ -68,5 +84,10 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Play against a trained PPO agent")
     parser.add_argument("--model", type=str, required=True, help="path to the saved model")
     parser.add_argument("--human-player", type=int, default=1, choices=[0, 1], help="0 to play first, 1 to play second")
+    parser.add_argument(
+        "--show-grid",
+        action="store_true",
+        help="display well numbering before the game starts",
+    )
     args = parser.parse_args()
-    play(args.model, args.human_player)
+    play(args.model, args.human_player, args.show_grid)


### PR DESCRIPTION
## Summary
- show reference grid numbering if requested
- render each board cell with its well index
- clarify well numbering in CLI prompt

## Testing
- `pytest -q`