### PR TITLE
Add architecture argument for PPO training

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ pytest
 
 # train a PPO agent against the tabular Q baseline
 python scripts/train_ppo.py --episodes 1000 --checkpoint ppo_agent.pkl --stage tabq
+# use the convolutional network instead of the default MLP
+python scripts/train_ppo.py --episodes 1000 --checkpoint ppo_conv.pkl --stage tabq --arch conv
 
 # continue training via self‑play
 # (start from a previous checkpoint and fight snapshots of the learner)

--- a/scripts/train_ppo.py
+++ b/scripts/train_ppo.py
@@ -79,15 +79,16 @@ def train(
     checkpoint: str | None = None,
     load: str | None = None,
     stage: str = "tabq",           # "tabq" or "pool"
+    architecture: str = "mlp",
 ):
     env = OtrioEnv(players=2)
-    learner = PPOAgent()
+    learner = PPOAgent(architecture=architecture)
 
     if stage == "tabq":
         opponent = TabularQAgent()
         opponent_pool = None
     elif stage == "pool":
-        opponent = PPOAgent()               # frozen opponent (weights replaced each episode)
+        opponent = PPOAgent(architecture=architecture)  # frozen opponent (weights replaced each episode)
         opponent_pool: list[dict[str, torch.Tensor]] = []
         # prime the pool with the learner's initial weights
         opponent_pool.append(copy.deepcopy(learner.state_dict()))
@@ -167,7 +168,14 @@ if __name__ == "__main__":
         type=str,
         default="tabq",
         choices=["tabq", "pool"],
-        help="Training stage: tabq (learner vs tabular‑Q) or pool (learner vs frozen snapshot pool)",
+        help="Training stage: tabq (learner vs tabular-Q) or pool (learner vs frozen snapshot pool)",
+    )
+    parser.add_argument(
+        "--arch",
+        type=str,
+        default="mlp",
+        choices=["mlp", "mlp2", "conv"],
+        help="Neural network architecture: mlp, mlp2, or conv",
     )
     args = parser.parse_args()
-    train(args.episodes, args.checkpoint, args.load, args.stage)
+    train(args.episodes, args.checkpoint, args.load, args.stage, args.arch)

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -36,3 +36,12 @@ def test_ppo_pool_training(tmp_path):
         check=True,
     )
     assert checkpoint.exists()
+
+
+def test_ppo_conv_training(tmp_path):
+    checkpoint = tmp_path / "ppo_conv.pkl"
+    subprocess.run(
+        [sys.executable, "scripts/train_ppo.py", "--episodes", "1", "--arch", "conv", "--checkpoint", str(checkpoint)],
+        check=True,
+    )
+    assert checkpoint.exists()


### PR DESCRIPTION
## Summary
- make PPO training script accept `--arch` to choose network type
- use chosen architecture for learner and opponent
- document convolutional training example in README
- test convolutional architecture via CLI

## Testing
- `pytest -q`