### PR TITLE
Add architecture arg to play scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,9 +133,12 @@ python scripts/train_ppo.py --episodes 1000 --stage pool \
 python scripts/train_tabular_q.py --episodes 1000 --checkpoint q_agent.pkl
 
 # play against your trained PPO agent
+# specify --arch if the model was trained with a non-default architecture
 python scripts/play_vs_ppo.py --model checkpoints/selfplay_ppo.pt
+python scripts/play_vs_ppo.py --model checkpoints/ppo_conv.pkl --arch conv
 # or launch a simple web UI via Streamlit
 streamlit run scripts/play_vs_ppo_streamlit.py -- --model checkpoints/selfplay_ppo.pt
+streamlit run scripts/play_vs_ppo_streamlit.py -- --model checkpoints/ppo_conv.pkl --arch conv
 ```
 
 Logs (TensorBoard & CSV) land in `./runs/`, checkpoints in `./checkpoints/`.

--- a/scripts/play_vs_ppo.py
+++ b/scripts/play_vs_ppo.py
@@ -49,9 +49,9 @@ def prompt_move(board, player):
             print("Invalid input, try again.")
 
 
-def play(model_path: str, human_player: int = 1, show_grid: bool = False):
+def play(model_path: str, human_player: int = 1, show_grid: bool = False, arch: str = "mlp"):
     env = OtrioEnv(players=2)
-    agent = PPOAgent()
+    agent = PPOAgent(architecture=arch)
     agent.load(model_path)
 
     obs, info = env.reset()
@@ -89,5 +89,12 @@ if __name__ == "__main__":
         action="store_true",
         help="display well numbering before the game starts",
     )
+    parser.add_argument(
+        "--arch",
+        type=str,
+        default="mlp",
+        choices=["mlp", "mlp2", "conv"],
+        help="Architecture used when training the model",
+    )
     args = parser.parse_args()
-    play(args.model, args.human_player, args.show_grid)
+    play(args.model, args.human_player, args.show_grid, args.arch)

--- a/scripts/play_vs_ppo_streamlit.py
+++ b/scripts/play_vs_ppo_streamlit.py
@@ -18,6 +18,13 @@ def parse_args():
     parser = argparse.ArgumentParser(description="Play PPO agent with Streamlit UI")
     parser.add_argument("--model", type=str, required=True, help="path to saved model")
     parser.add_argument("--human-player", type=int, default=1, choices=[0, 1], help="0 to play first, 1 to play second")
+    parser.add_argument(
+        "--arch",
+        type=str,
+        default="mlp",
+        choices=["mlp", "mlp2", "conv"],
+        help="Architecture used when training the model",
+    )
     return parser.parse_args()
 
 
@@ -26,7 +33,7 @@ args = parse_args()
 
 def init_game():
     env = OtrioEnv(players=2)
-    agent = PPOAgent()
+    agent = PPOAgent(architecture=args.arch)
     agent.load(args.model)
     obs, info = env.reset()
     st.session_state.env = env


### PR DESCRIPTION
## Summary
- support specifying PPO architecture when playing against a saved model
- update Streamlit and CLI play scripts accordingly
- document `--arch` usage in README

## Testing
- `pytest -q`